### PR TITLE
Fix for Release build failure

### DIFF
--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -15,10 +15,9 @@ trigger:
 pr: none
 
 steps:
-- task: UseDotNet@2
+- task: DotNetCoreInstaller@0
   displayName: 'Use .NET Core sdk'
   inputs:
-    packageType: sdk
     version: 3.0.100-preview9-014004
     
 - script: dotnet build --configuration $(buildConfiguration)

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -42,6 +42,10 @@ steps:
     arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)'
     zipAfterPublish: false
 
+- task: NuGetToolInstaller@0
+  inputs:
+    versionSpec: 5.2.0
+
 - task: NuGetCommand@2
   displayName: 'NuGet pack'
   inputs:

--- a/src/NodaTimePicker.Demo/Shared/MainLayout.razor
+++ b/src/NodaTimePicker.Demo/Shared/MainLayout.razor
@@ -6,7 +6,7 @@
 
 <div class="main">
 	<div class="top-row px-4">
-		<a href="https://github.com/nheath99/BlazorNodaTimeDateTimePicker" target="_blank" class="ml-md-auto text-dark">
+		<a href="https://github.com/nheath99/NodaTimePicker" target="_blank" class="ml-md-auto text-dark">
 			<span class="fab fa-2x fa-github"></span>
 		</a>
 	</div>

--- a/src/NodaTimePicker/NodaTimePicker.csproj
+++ b/src/NodaTimePicker/NodaTimePicker.csproj
@@ -26,4 +26,8 @@
     <PackageReference Include="NodaTime" Version="3.0.0-beta01" />
   </ItemGroup>
 
+	<ItemGroup>		
+		<EmbeddedResource Include="wwwroot\**\*.css" LogicalName="blazor:css:%(RecursiveDir)%(Filename)%(Extension)" />		
+	</ItemGroup>
+	
 </Project>


### PR DESCRIPTION
In azure-pipelines.release.yml: 
Updating DotNetCoreInstaller@0 to UseDotNet@2 caused the subsequent NuGet Pack task to fail. Reverted.